### PR TITLE
Fixed bug where auth creds weren't properly URL escaped

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v0.1.1
+
+* Fixed API authentication not working when username/password contains special characters.
+  Now usernames and passwords are passed into `requests` properly so they are URL encoded, escaping
+  any special characters. (Bugfix)
+  
+  Contributed by Nick Maludy (@nmaludy Encore Technologies)
+
 ## v0.1.0
 
-Initial Revision
+* Initial Revision

--- a/actions/ipa_action.py
+++ b/actions/ipa_action.py
@@ -128,11 +128,17 @@ class IpaAction(Action):
             "Content-Type": "application/x-www-form-urlencoded",
             "Accept": "text/plain"
         }
-        payload = "user={0}&password={1}".format(username, password)
-
+        # pass this in as a dictionary so the username and password are URL encoded
+        # into a query string appropriate for application/x-www-form-urlencoded
+        # this will also escape any special characters in the username or password
+        # with URL encoding semantics
+        data = {
+            'user': username,
+            'password': password
+        }
         response = self.session.post(url,
                                      headers=headers,
-                                     data=payload)
+                                     data=data)
         self._raise_for_status(response)
 
         session = ''

--- a/pack.yaml
+++ b/pack.yaml
@@ -10,6 +10,6 @@ keywords:
     - red
     - hat
     - authentication
-version: 0.1.0
+version: 0.1.1
 author: Encore Technologies
 email: code@encore.tech

--- a/tests/test_actions_ipa_action.py
+++ b/tests/test_actions_ipa_action.py
@@ -137,8 +137,10 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
         headers = {"referer": 'https://{0}/ipa'.format(connection['server']),
                    "Content-Type": "application/x-www-form-urlencoded",
                    "Accept": "text/plain"}
-        payload = 'user={0}&password={1}'.format(connection['username'],
-                                                 connection['password'])
+        data = {
+            'user': connection['username'],
+            'password': connection['password']
+        }
 
         # execute
         result = action._login(connection)
@@ -146,7 +148,7 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
         # verify
         mock_session.post.assert_called_with(url,
                                              headers=headers,
-                                             data=payload)
+                                             data=data)
         self.assertEqual(result, expected_session)
 
     def test__login_error(self):
@@ -165,8 +167,10 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
         headers = {"referer": 'https://{0}/ipa'.format(connection['server']),
                    "Content-Type": "application/x-www-form-urlencoded",
                    "Accept": "text/plain"}
-        payload = 'user={0}&password={1}'.format(connection['username'],
-                                                 connection['password'])
+        data = {
+            'user': connection['username'],
+            'password': connection['password']
+        }
 
         # execute
         with self.assertRaises(RuntimeError):
@@ -175,7 +179,7 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
         # verify
         mock_session.post.assert_called_with(url,
                                              headers=headers,
-                                             data=payload)
+                                             data=data)
 
     def test__login_http_error(self):
         # setup
@@ -193,8 +197,10 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
         headers = {"referer": 'https://{0}/ipa'.format(connection['server']),
                    "Content-Type": "application/x-www-form-urlencoded",
                    "Accept": "text/plain"}
-        payload = 'user={0}&password={1}'.format(connection['username'],
-                                                 connection['password'])
+        data = {
+            'user': connection['username'],
+            'password': connection['password']
+        }
 
         # execute
         with self.assertRaises(requests.HTTPError):
@@ -203,7 +209,7 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
         # verify
         mock_session.post.assert_called_with(url,
                                              headers=headers,
-                                             data=payload)
+                                             data=data)
 
     def test__create_payload(self):
         action = self.get_action_instance(self.config_good)


### PR DESCRIPTION
Found a bug this morning where special characters in usernames/passwords weren't being properly URL encoded. When they were sent to the server it was rejecting or mangling the data causing auth failures.

Simple fix was to pass the form data to requests as a dict instead of a string and let it escape the parameters and create the form data for us :)
