### PR TITLE
update/fix-scripts-to-work-with-st2-35

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v1.1.0
+
+* Updated config and generate_actions template to rename connection variables because some of them were duplicated in other actions
+
+  Contributed by John Schoewe (Encore Technologies)
+
 ## v1.0.0
 
 * Drop Python 2.7 support

--- a/actions/aci_add.yaml
+++ b/actions/aci_add.yaml
@@ -68,7 +68,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "aci_add"
@@ -84,15 +84,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/aci_del.yaml
+++ b/actions/aci_del.yaml
@@ -22,7 +22,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "aci_del"
@@ -38,15 +38,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/aci_find.yaml
+++ b/actions/aci_find.yaml
@@ -70,7 +70,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "aci_find"
@@ -86,15 +86,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/aci_mod.yaml
+++ b/actions/aci_mod.yaml
@@ -65,7 +65,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "aci_mod"
@@ -81,15 +81,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/aci_rename.yaml
+++ b/actions/aci_rename.yaml
@@ -67,7 +67,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "aci_rename"
@@ -83,15 +83,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/aci_show.yaml
+++ b/actions/aci_show.yaml
@@ -32,7 +32,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "aci_show"
@@ -48,15 +48,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/adtrust_is_enabled.yaml
+++ b/actions/adtrust_is_enabled.yaml
@@ -12,7 +12,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "adtrust_is_enabled"
@@ -28,15 +28,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automember_add.yaml
+++ b/actions/automember_add.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automember_add"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automember_add_condition.yaml
+++ b/actions/automember_add_condition.yaml
@@ -40,7 +40,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automember_add_condition"
@@ -56,15 +56,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automember_default_group_remove.yaml
+++ b/actions/automember_default_group_remove.yaml
@@ -28,7 +28,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automember_default_group_remove"
@@ -44,15 +44,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automember_default_group_set.yaml
+++ b/actions/automember_default_group_set.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automember_default_group_set"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automember_default_group_show.yaml
+++ b/actions/automember_default_group_show.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automember_default_group_show"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automember_del.yaml
+++ b/actions/automember_del.yaml
@@ -21,7 +21,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automember_del"
@@ -37,15 +37,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automember_find.yaml
+++ b/actions/automember_find.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automember_find"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automember_find_orphans.yaml
+++ b/actions/automember_find_orphans.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automember_find_orphans"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automember_mod.yaml
+++ b/actions/automember_mod.yaml
@@ -46,7 +46,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automember_mod"
@@ -62,15 +62,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automember_rebuild.yaml
+++ b/actions/automember_rebuild.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automember_rebuild"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automember_remove_condition.yaml
+++ b/actions/automember_remove_condition.yaml
@@ -40,7 +40,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automember_remove_condition"
@@ -56,15 +56,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automember_show.yaml
+++ b/actions/automember_show.yaml
@@ -28,7 +28,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automember_show"
@@ -44,15 +44,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automountkey_add.yaml
+++ b/actions/automountkey_add.yaml
@@ -36,7 +36,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automountkey_add"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automountkey_del.yaml
+++ b/actions/automountkey_del.yaml
@@ -24,7 +24,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automountkey_del"
@@ -40,15 +40,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automountkey_find.yaml
+++ b/actions/automountkey_find.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automountkey_find"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automountkey_mod.yaml
+++ b/actions/automountkey_mod.yaml
@@ -48,7 +48,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automountkey_mod"
@@ -64,15 +64,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automountkey_show.yaml
+++ b/actions/automountkey_show.yaml
@@ -32,7 +32,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automountkey_show"
@@ -48,15 +48,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automountlocation_add.yaml
+++ b/actions/automountlocation_add.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automountlocation_add"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automountlocation_del.yaml
+++ b/actions/automountlocation_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automountlocation_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automountlocation_find.yaml
+++ b/actions/automountlocation_find.yaml
@@ -32,7 +32,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automountlocation_find"
@@ -48,15 +48,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automountlocation_show.yaml
+++ b/actions/automountlocation_show.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automountlocation_show"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automountlocation_tofiles.yaml
+++ b/actions/automountlocation_tofiles.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automountlocation_tofiles"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automountmap_add.yaml
+++ b/actions/automountmap_add.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automountmap_add"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automountmap_add_indirect.yaml
+++ b/actions/automountmap_add_indirect.yaml
@@ -40,7 +40,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automountmap_add_indirect"
@@ -56,15 +56,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automountmap_del.yaml
+++ b/actions/automountmap_del.yaml
@@ -21,7 +21,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automountmap_del"
@@ -37,15 +37,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automountmap_find.yaml
+++ b/actions/automountmap_find.yaml
@@ -36,7 +36,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automountmap_find"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automountmap_mod.yaml
+++ b/actions/automountmap_mod.yaml
@@ -42,7 +42,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automountmap_mod"
@@ -58,15 +58,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/automountmap_show.yaml
+++ b/actions/automountmap_show.yaml
@@ -28,7 +28,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "automountmap_show"
@@ -44,15 +44,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/batch.yaml
+++ b/actions/batch.yaml
@@ -16,7 +16,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "batch"
@@ -32,15 +32,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/ca_add.yaml
+++ b/actions/ca_add.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "ca_add"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/ca_del.yaml
+++ b/actions/ca_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "ca_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/ca_disable.yaml
+++ b/actions/ca_disable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "ca_disable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/ca_enable.yaml
+++ b/actions/ca_enable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "ca_enable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/ca_find.yaml
+++ b/actions/ca_find.yaml
@@ -40,7 +40,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "ca_find"
@@ -56,15 +56,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/ca_is_enabled.yaml
+++ b/actions/ca_is_enabled.yaml
@@ -12,7 +12,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "ca_is_enabled"
@@ -28,15 +28,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/ca_mod.yaml
+++ b/actions/ca_mod.yaml
@@ -42,7 +42,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "ca_mod"
@@ -58,15 +58,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/ca_show.yaml
+++ b/actions/ca_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "ca_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_add.yaml
+++ b/actions/caacl_add.yaml
@@ -63,7 +63,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_add"
@@ -79,15 +79,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_add_ca.yaml
+++ b/actions/caacl_add_ca.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_add_ca"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_add_host.yaml
+++ b/actions/caacl_add_host.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_add_host"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_add_profile.yaml
+++ b/actions/caacl_add_profile.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_add_profile"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_add_service.yaml
+++ b/actions/caacl_add_service.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_add_service"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_add_user.yaml
+++ b/actions/caacl_add_user.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_add_user"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_del.yaml
+++ b/actions/caacl_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_disable.yaml
+++ b/actions/caacl_disable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_disable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_enable.yaml
+++ b/actions/caacl_enable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_enable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_find.yaml
+++ b/actions/caacl_find.yaml
@@ -65,7 +65,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_find"
@@ -81,15 +81,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_mod.yaml
+++ b/actions/caacl_mod.yaml
@@ -71,7 +71,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_mod"
@@ -87,15 +87,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_remove_ca.yaml
+++ b/actions/caacl_remove_ca.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_remove_ca"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_remove_host.yaml
+++ b/actions/caacl_remove_host.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_remove_host"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_remove_profile.yaml
+++ b/actions/caacl_remove_profile.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_remove_profile"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_remove_service.yaml
+++ b/actions/caacl_remove_service.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_remove_service"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_remove_user.yaml
+++ b/actions/caacl_remove_user.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_remove_user"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/caacl_show.yaml
+++ b/actions/caacl_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "caacl_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/cert_find.yaml
+++ b/actions/cert_find.yaml
@@ -92,7 +92,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "cert_find"
@@ -108,15 +108,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/cert_remove_hold.yaml
+++ b/actions/cert_remove_hold.yaml
@@ -18,7 +18,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "cert_remove_hold"
@@ -34,15 +34,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/cert_request.yaml
+++ b/actions/cert_request.yaml
@@ -42,7 +42,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "cert_request"
@@ -58,15 +58,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/cert_revoke.yaml
+++ b/actions/cert_revoke.yaml
@@ -22,7 +22,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "cert_revoke"
@@ -38,15 +38,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/cert_show.yaml
+++ b/actions/cert_show.yaml
@@ -36,7 +36,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "cert_show"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/cert_status.yaml
+++ b/actions/cert_status.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "cert_status"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/certmap_match.yaml
+++ b/actions/certmap_match.yaml
@@ -22,7 +22,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "certmap_match"
@@ -38,15 +38,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/certmapconfig_mod.yaml
+++ b/actions/certmapconfig_mod.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "certmapconfig_mod"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/certmapconfig_show.yaml
+++ b/actions/certmapconfig_show.yaml
@@ -24,7 +24,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "certmapconfig_show"
@@ -40,15 +40,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/certmaprule_add.yaml
+++ b/actions/certmaprule_add.yaml
@@ -46,7 +46,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "certmaprule_add"
@@ -62,15 +62,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/certmaprule_del.yaml
+++ b/actions/certmaprule_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "certmaprule_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/certmaprule_disable.yaml
+++ b/actions/certmaprule_disable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "certmaprule_disable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/certmaprule_enable.yaml
+++ b/actions/certmaprule_enable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "certmaprule_enable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/certmaprule_find.yaml
+++ b/actions/certmaprule_find.yaml
@@ -47,7 +47,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "certmaprule_find"
@@ -63,15 +63,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/certmaprule_mod.yaml
+++ b/actions/certmaprule_mod.yaml
@@ -54,7 +54,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "certmaprule_mod"
@@ -70,15 +70,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/certmaprule_show.yaml
+++ b/actions/certmaprule_show.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "certmaprule_show"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/certprofile_del.yaml
+++ b/actions/certprofile_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "certprofile_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/certprofile_find.yaml
+++ b/actions/certprofile_find.yaml
@@ -37,7 +37,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "certprofile_find"
@@ -53,15 +53,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/certprofile_import.yaml
+++ b/actions/certprofile_import.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "certprofile_import"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/certprofile_mod.yaml
+++ b/actions/certprofile_mod.yaml
@@ -45,7 +45,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "certprofile_mod"
@@ -61,15 +61,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/certprofile_show.yaml
+++ b/actions/certprofile_show.yaml
@@ -28,7 +28,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "certprofile_show"
@@ -44,15 +44,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/class_find.yaml
+++ b/actions/class_find.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "class_find"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/class_show.yaml
+++ b/actions/class_show.yaml
@@ -22,7 +22,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "class_show"
@@ -38,15 +38,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/command_defaults.yaml
+++ b/actions/command_defaults.yaml
@@ -20,7 +20,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "command_defaults"
@@ -36,15 +36,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/command_find.yaml
+++ b/actions/command_find.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "command_find"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/command_show.yaml
+++ b/actions/command_show.yaml
@@ -22,7 +22,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "command_show"
@@ -38,15 +38,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/compat_is_enabled.yaml
+++ b/actions/compat_is_enabled.yaml
@@ -12,7 +12,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "compat_is_enabled"
@@ -28,15 +28,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/config_mod.yaml
+++ b/actions/config_mod.yaml
@@ -107,7 +107,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "config_mod"
@@ -123,15 +123,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/config_show.yaml
+++ b/actions/config_show.yaml
@@ -24,7 +24,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "config_show"
@@ -40,15 +40,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/cosentry_add.yaml
+++ b/actions/cosentry_add.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "cosentry_add"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/cosentry_del.yaml
+++ b/actions/cosentry_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "cosentry_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/cosentry_find.yaml
+++ b/actions/cosentry_find.yaml
@@ -36,7 +36,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "cosentry_find"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/cosentry_mod.yaml
+++ b/actions/cosentry_mod.yaml
@@ -42,7 +42,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "cosentry_mod"
@@ -58,15 +58,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/cosentry_show.yaml
+++ b/actions/cosentry_show.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "cosentry_show"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/delegation_add.yaml
+++ b/actions/delegation_add.yaml
@@ -33,7 +33,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "delegation_add"
@@ -49,15 +49,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/delegation_del.yaml
+++ b/actions/delegation_del.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "delegation_del"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/delegation_find.yaml
+++ b/actions/delegation_find.yaml
@@ -40,7 +40,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "delegation_find"
@@ -56,15 +56,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/delegation_mod.yaml
+++ b/actions/delegation_mod.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "delegation_mod"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/delegation_show.yaml
+++ b/actions/delegation_show.yaml
@@ -22,7 +22,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "delegation_show"
@@ -38,15 +38,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dns_is_enabled.yaml
+++ b/actions/dns_is_enabled.yaml
@@ -12,7 +12,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dns_is_enabled"
@@ -28,15 +28,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dns_resolve.yaml
+++ b/actions/dns_resolve.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dns_resolve"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dns_update_system_records.yaml
+++ b/actions/dns_update_system_records.yaml
@@ -24,7 +24,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dns_update_system_records"
@@ -40,15 +40,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsconfig_mod.yaml
+++ b/actions/dnsconfig_mod.yaml
@@ -51,7 +51,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsconfig_mod"
@@ -67,15 +67,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsconfig_show.yaml
+++ b/actions/dnsconfig_show.yaml
@@ -24,7 +24,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsconfig_show"
@@ -40,15 +40,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsforwardzone_add.yaml
+++ b/actions/dnsforwardzone_add.yaml
@@ -47,7 +47,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsforwardzone_add"
@@ -63,15 +63,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsforwardzone_add_permission.yaml
+++ b/actions/dnsforwardzone_add_permission.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsforwardzone_add_permission"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsforwardzone_del.yaml
+++ b/actions/dnsforwardzone_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsforwardzone_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsforwardzone_disable.yaml
+++ b/actions/dnsforwardzone_disable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsforwardzone_disable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsforwardzone_enable.yaml
+++ b/actions/dnsforwardzone_enable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsforwardzone_enable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsforwardzone_find.yaml
+++ b/actions/dnsforwardzone_find.yaml
@@ -47,7 +47,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsforwardzone_find"
@@ -63,15 +63,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsforwardzone_mod.yaml
+++ b/actions/dnsforwardzone_mod.yaml
@@ -51,7 +51,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsforwardzone_mod"
@@ -67,15 +67,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsforwardzone_remove_permission.yaml
+++ b/actions/dnsforwardzone_remove_permission.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsforwardzone_remove_permission"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsforwardzone_show.yaml
+++ b/actions/dnsforwardzone_show.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsforwardzone_show"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsrecord_add.yaml
+++ b/actions/dnsrecord_add.yaml
@@ -302,7 +302,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsrecord_add"
@@ -318,15 +318,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsrecord_del.yaml
+++ b/actions/dnsrecord_del.yaml
@@ -158,7 +158,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsrecord_del"
@@ -174,15 +174,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsrecord_delentry.yaml
+++ b/actions/dnsrecord_delentry.yaml
@@ -21,7 +21,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsrecord_delentry"
@@ -37,15 +37,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsrecord_find.yaml
+++ b/actions/dnsrecord_find.yaml
@@ -168,7 +168,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsrecord_find"
@@ -184,15 +184,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsrecord_mod.yaml
+++ b/actions/dnsrecord_mod.yaml
@@ -300,7 +300,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsrecord_mod"
@@ -316,15 +316,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsrecord_show.yaml
+++ b/actions/dnsrecord_show.yaml
@@ -32,7 +32,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsrecord_show"
@@ -48,15 +48,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsrecord_split_parts.yaml
+++ b/actions/dnsrecord_split_parts.yaml
@@ -16,7 +16,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsrecord_split_parts"
@@ -32,15 +32,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsserver_add.yaml
+++ b/actions/dnsserver_add.yaml
@@ -43,7 +43,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsserver_add"
@@ -59,15 +59,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsserver_del.yaml
+++ b/actions/dnsserver_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsserver_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsserver_find.yaml
+++ b/actions/dnsserver_find.yaml
@@ -45,7 +45,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsserver_find"
@@ -61,15 +61,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsserver_mod.yaml
+++ b/actions/dnsserver_mod.yaml
@@ -51,7 +51,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsserver_mod"
@@ -67,15 +67,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnsserver_show.yaml
+++ b/actions/dnsserver_show.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnsserver_show"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnszone_add.yaml
+++ b/actions/dnszone_add.yaml
@@ -114,7 +114,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnszone_add"
@@ -130,15 +130,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnszone_add_permission.yaml
+++ b/actions/dnszone_add_permission.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnszone_add_permission"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnszone_del.yaml
+++ b/actions/dnszone_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnszone_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnszone_disable.yaml
+++ b/actions/dnszone_disable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnszone_disable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnszone_enable.yaml
+++ b/actions/dnszone_enable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnszone_enable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnszone_find.yaml
+++ b/actions/dnszone_find.yaml
@@ -99,7 +99,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnszone_find"
@@ -115,15 +115,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnszone_mod.yaml
+++ b/actions/dnszone_mod.yaml
@@ -103,7 +103,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnszone_mod"
@@ -119,15 +119,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnszone_remove_permission.yaml
+++ b/actions/dnszone_remove_permission.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnszone_remove_permission"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/dnszone_show.yaml
+++ b/actions/dnszone_show.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "dnszone_show"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/domainlevel_get.yaml
+++ b/actions/domainlevel_get.yaml
@@ -12,7 +12,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "domainlevel_get"
@@ -28,15 +28,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/domainlevel_set.yaml
+++ b/actions/domainlevel_set.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "domainlevel_set"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/env.yaml
+++ b/actions/env.yaml
@@ -24,7 +24,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "env"
@@ -40,15 +40,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/group_add.yaml
+++ b/actions/group_add.yaml
@@ -46,7 +46,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "group_add"
@@ -62,15 +62,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/group_add_member.yaml
+++ b/actions/group_add_member.yaml
@@ -46,7 +46,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "group_add_member"
@@ -62,15 +62,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/group_add_member_manager.yaml
+++ b/actions/group_add_member_manager.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "group_add_member_manager"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/group_del.yaml
+++ b/actions/group_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "group_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/group_detach.yaml
+++ b/actions/group_detach.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "group_detach"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/group_find.yaml
+++ b/actions/group_find.yaml
@@ -144,7 +144,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "group_find"
@@ -160,15 +160,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/group_mod.yaml
+++ b/actions/group_mod.yaml
@@ -56,7 +56,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "group_mod"
@@ -72,15 +72,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/group_remove_member.yaml
+++ b/actions/group_remove_member.yaml
@@ -46,7 +46,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "group_remove_member"
@@ -62,15 +62,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/group_remove_member_manager.yaml
+++ b/actions/group_remove_member_manager.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "group_remove_member_manager"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/group_show.yaml
+++ b/actions/group_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "group_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacrule_add.yaml
+++ b/actions/hbacrule_add.yaml
@@ -70,7 +70,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacrule_add"
@@ -86,15 +86,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacrule_add_host.yaml
+++ b/actions/hbacrule_add_host.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacrule_add_host"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacrule_add_service.yaml
+++ b/actions/hbacrule_add_service.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacrule_add_service"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacrule_add_sourcehost.yaml
+++ b/actions/hbacrule_add_sourcehost.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacrule_add_sourcehost"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacrule_add_user.yaml
+++ b/actions/hbacrule_add_user.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacrule_add_user"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacrule_del.yaml
+++ b/actions/hbacrule_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacrule_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacrule_disable.yaml
+++ b/actions/hbacrule_disable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacrule_disable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacrule_enable.yaml
+++ b/actions/hbacrule_enable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacrule_enable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacrule_find.yaml
+++ b/actions/hbacrule_find.yaml
@@ -71,7 +71,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacrule_find"
@@ -87,15 +87,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacrule_mod.yaml
+++ b/actions/hbacrule_mod.yaml
@@ -79,7 +79,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacrule_mod"
@@ -95,15 +95,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacrule_remove_host.yaml
+++ b/actions/hbacrule_remove_host.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacrule_remove_host"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacrule_remove_service.yaml
+++ b/actions/hbacrule_remove_service.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacrule_remove_service"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacrule_remove_sourcehost.yaml
+++ b/actions/hbacrule_remove_sourcehost.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacrule_remove_sourcehost"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacrule_remove_user.yaml
+++ b/actions/hbacrule_remove_user.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacrule_remove_user"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacrule_show.yaml
+++ b/actions/hbacrule_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacrule_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacsvc_add.yaml
+++ b/actions/hbacsvc_add.yaml
@@ -36,7 +36,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacsvc_add"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacsvc_del.yaml
+++ b/actions/hbacsvc_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacsvc_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacsvc_find.yaml
+++ b/actions/hbacsvc_find.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacsvc_find"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacsvc_mod.yaml
+++ b/actions/hbacsvc_mod.yaml
@@ -44,7 +44,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacsvc_mod"
@@ -60,15 +60,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacsvc_show.yaml
+++ b/actions/hbacsvc_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacsvc_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacsvcgroup_add.yaml
+++ b/actions/hbacsvcgroup_add.yaml
@@ -36,7 +36,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacsvcgroup_add"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacsvcgroup_add_member.yaml
+++ b/actions/hbacsvcgroup_add_member.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacsvcgroup_add_member"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacsvcgroup_del.yaml
+++ b/actions/hbacsvcgroup_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacsvcgroup_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacsvcgroup_find.yaml
+++ b/actions/hbacsvcgroup_find.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacsvcgroup_find"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacsvcgroup_mod.yaml
+++ b/actions/hbacsvcgroup_mod.yaml
@@ -44,7 +44,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacsvcgroup_mod"
@@ -60,15 +60,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacsvcgroup_remove_member.yaml
+++ b/actions/hbacsvcgroup_remove_member.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacsvcgroup_remove_member"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbacsvcgroup_show.yaml
+++ b/actions/hbacsvcgroup_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbacsvcgroup_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hbactest.yaml
+++ b/actions/hbactest.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hbactest"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/host_add.yaml
+++ b/actions/host_add.yaml
@@ -94,7 +94,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "host_add"
@@ -110,15 +110,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/host_add_cert.yaml
+++ b/actions/host_add_cert.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "host_add_cert"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/host_add_managedby.yaml
+++ b/actions/host_add_managedby.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "host_add_managedby"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/host_add_principal.yaml
+++ b/actions/host_add_principal.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "host_add_principal"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/host_allow_create_keytab.yaml
+++ b/actions/host_allow_create_keytab.yaml
@@ -42,7 +42,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "host_allow_create_keytab"
@@ -58,15 +58,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/host_allow_retrieve_keytab.yaml
+++ b/actions/host_allow_retrieve_keytab.yaml
@@ -42,7 +42,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "host_allow_retrieve_keytab"
@@ -58,15 +58,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/host_del.yaml
+++ b/actions/host_del.yaml
@@ -23,7 +23,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "host_del"
@@ -39,15 +39,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/host_disable.yaml
+++ b/actions/host_disable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "host_disable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/host_disallow_create_keytab.yaml
+++ b/actions/host_disallow_create_keytab.yaml
@@ -42,7 +42,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "host_disallow_create_keytab"
@@ -58,15 +58,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/host_disallow_retrieve_keytab.yaml
+++ b/actions/host_disallow_retrieve_keytab.yaml
@@ -42,7 +42,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "host_disallow_retrieve_keytab"
@@ -58,15 +58,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/host_find.yaml
+++ b/actions/host_find.yaml
@@ -134,7 +134,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "host_find"
@@ -150,15 +150,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/host_mod.yaml
+++ b/actions/host_mod.yaml
@@ -100,7 +100,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "host_mod"
@@ -116,15 +116,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/host_remove_cert.yaml
+++ b/actions/host_remove_cert.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "host_remove_cert"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/host_remove_managedby.yaml
+++ b/actions/host_remove_managedby.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "host_remove_managedby"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/host_remove_principal.yaml
+++ b/actions/host_remove_principal.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "host_remove_principal"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/host_show.yaml
+++ b/actions/host_show.yaml
@@ -32,7 +32,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "host_show"
@@ -48,15 +48,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hostgroup_add.yaml
+++ b/actions/hostgroup_add.yaml
@@ -36,7 +36,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hostgroup_add"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hostgroup_add_member.yaml
+++ b/actions/hostgroup_add_member.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hostgroup_add_member"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hostgroup_add_member_manager.yaml
+++ b/actions/hostgroup_add_member_manager.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hostgroup_add_member_manager"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hostgroup_del.yaml
+++ b/actions/hostgroup_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hostgroup_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hostgroup_find.yaml
+++ b/actions/hostgroup_find.yaml
@@ -102,7 +102,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hostgroup_find"
@@ -118,15 +118,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hostgroup_mod.yaml
+++ b/actions/hostgroup_mod.yaml
@@ -46,7 +46,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hostgroup_mod"
@@ -62,15 +62,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hostgroup_remove_member.yaml
+++ b/actions/hostgroup_remove_member.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hostgroup_remove_member"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hostgroup_remove_member_manager.yaml
+++ b/actions/hostgroup_remove_member_manager.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hostgroup_remove_member_manager"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/hostgroup_show.yaml
+++ b/actions/hostgroup_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "hostgroup_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/i18n_messages.yaml
+++ b/actions/i18n_messages.yaml
@@ -12,7 +12,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "i18n_messages"
@@ -28,15 +28,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idoverridegroup_add.yaml
+++ b/actions/idoverridegroup_add.yaml
@@ -42,7 +42,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idoverridegroup_add"
@@ -58,15 +58,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idoverridegroup_del.yaml
+++ b/actions/idoverridegroup_del.yaml
@@ -25,7 +25,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idoverridegroup_del"
@@ -41,15 +41,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idoverridegroup_find.yaml
+++ b/actions/idoverridegroup_find.yaml
@@ -44,7 +44,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idoverridegroup_find"
@@ -60,15 +60,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idoverridegroup_mod.yaml
+++ b/actions/idoverridegroup_mod.yaml
@@ -52,7 +52,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idoverridegroup_mod"
@@ -68,15 +68,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idoverridegroup_show.yaml
+++ b/actions/idoverridegroup_show.yaml
@@ -32,7 +32,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idoverridegroup_show"
@@ -48,15 +48,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idoverrideuser_add.yaml
+++ b/actions/idoverrideuser_add.yaml
@@ -64,7 +64,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idoverrideuser_add"
@@ -80,15 +80,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idoverrideuser_add_cert.yaml
+++ b/actions/idoverrideuser_add_cert.yaml
@@ -35,7 +35,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idoverrideuser_add_cert"
@@ -51,15 +51,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idoverrideuser_del.yaml
+++ b/actions/idoverrideuser_del.yaml
@@ -25,7 +25,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idoverrideuser_del"
@@ -41,15 +41,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idoverrideuser_find.yaml
+++ b/actions/idoverrideuser_find.yaml
@@ -58,7 +58,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idoverrideuser_find"
@@ -74,15 +74,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idoverrideuser_mod.yaml
+++ b/actions/idoverrideuser_mod.yaml
@@ -74,7 +74,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idoverrideuser_mod"
@@ -90,15 +90,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idoverrideuser_remove_cert.yaml
+++ b/actions/idoverrideuser_remove_cert.yaml
@@ -35,7 +35,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idoverrideuser_remove_cert"
@@ -51,15 +51,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idoverrideuser_show.yaml
+++ b/actions/idoverrideuser_show.yaml
@@ -36,7 +36,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idoverrideuser_show"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idrange_add.yaml
+++ b/actions/idrange_add.yaml
@@ -49,7 +49,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idrange_add"
@@ -65,15 +65,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idrange_del.yaml
+++ b/actions/idrange_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idrange_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idrange_find.yaml
+++ b/actions/idrange_find.yaml
@@ -49,7 +49,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idrange_find"
@@ -65,15 +65,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idrange_mod.yaml
+++ b/actions/idrange_mod.yaml
@@ -50,7 +50,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idrange_mod"
@@ -66,15 +66,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idrange_show.yaml
+++ b/actions/idrange_show.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idrange_show"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idview_add.yaml
+++ b/actions/idview_add.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idview_add"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idview_apply.yaml
+++ b/actions/idview_apply.yaml
@@ -22,7 +22,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idview_apply"
@@ -38,15 +38,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idview_del.yaml
+++ b/actions/idview_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idview_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idview_find.yaml
+++ b/actions/idview_find.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idview_find"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idview_mod.yaml
+++ b/actions/idview_mod.yaml
@@ -44,7 +44,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idview_mod"
@@ -60,15 +60,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idview_show.yaml
+++ b/actions/idview_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idview_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/idview_unapply.yaml
+++ b/actions/idview_unapply.yaml
@@ -20,7 +20,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "idview_unapply"
@@ -36,15 +36,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/ipa_action.py
+++ b/actions/ipa_action.py
@@ -150,10 +150,10 @@ class IpaAction(Action):
         self.logger.debug('Successfully logged in as {0}'.format(username))
         return session
 
-    def _create_payload(self, ipa_method, api_version=None, **kwargs):
+    def _create_payload(self, method, api_version=None, **kwargs):
         # lookup kwargs are in args vs options based on the auto-generated
         # data, in IPA_COMMAND_ARGS_OPTIONS (this gets generated from etc/generate_actions.py)
-        method_args_options = IPA_COMMAND_ARGS_OPTIONS[ipa_method]
+        method_args_options = IPA_COMMAND_ARGS_OPTIONS[method]
 
         # args go into an array
         args = []
@@ -173,7 +173,7 @@ class IpaAction(Action):
 
         payload = {
             "id": 0,
-            "method": ipa_method,
+            "method": method,
             "params": [
                 args,
                 options

--- a/actions/ipa_action.py
+++ b/actions/ipa_action.py
@@ -10,9 +10,9 @@ urllib3.disable_warnings()
 requests.packages.urllib3.disable_warnings()  # pylint: disable=no-member
 
 CONNECTION_OPTIONS = [
-    'server',
-    'username',
-    'password',
+    'ipa_server',
+    'ipa_username',
+    'ipa_password',
     'verify_ssl',
 ]
 
@@ -118,9 +118,9 @@ class IpaAction(Action):
         :returns: login session token upon successful login
         :rtype: string
         """
-        server = connection['server']
-        username = connection['username']
-        password = connection['password']
+        server = connection['ipa_server']
+        username = connection['ipa_username']
+        password = connection['ipa_password']
 
         url = self._ipa_url(server, '/session/login_password')
         headers = {
@@ -150,10 +150,10 @@ class IpaAction(Action):
         self.logger.debug('Successfully logged in as {0}'.format(username))
         return session
 
-    def _create_payload(self, method, api_version=None, **kwargs):
+    def _create_payload(self, ipa_method, api_version=None, **kwargs):
         # lookup kwargs are in args vs options based on the auto-generated
         # data, in IPA_COMMAND_ARGS_OPTIONS (this gets generated from etc/generate_actions.py)
-        method_args_options = IPA_COMMAND_ARGS_OPTIONS[method]
+        method_args_options = IPA_COMMAND_ARGS_OPTIONS[ipa_method]
 
         # args go into an array
         args = []
@@ -173,7 +173,7 @@ class IpaAction(Action):
 
         payload = {
             "id": 0,
-            "method": method,
+            "method": ipa_method,
             "params": [
                 args,
                 options
@@ -233,18 +233,18 @@ class IpaAction(Action):
         connection = self._resolve_connection(**kwargs)
         self._validate_connection(connection)
         self.session.verify = connection['verify_ssl']
-        method = kwargs['method']
+        method = kwargs['ipa_method']
 
         if 'session' in kwargs and kwargs['session']:
-            server = kwargs['server']
+            server = kwargs['ipa_server']
             session = kwargs['session']
         else:
-            server = connection['server']
+            server = connection['ipa_server']
             session = self._login(connection)
 
-        del kwargs['server']
+        del kwargs['ipa_server']
         del kwargs['session']
-        del kwargs['method']
+        del kwargs['ipa_method']
         del kwargs['verify_ssl']
 
         if method == 'login':

--- a/actions/join.yaml
+++ b/actions/join.yaml
@@ -22,7 +22,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "join"
@@ -38,15 +38,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/json_metadata.yaml
+++ b/actions/json_metadata.yaml
@@ -22,7 +22,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "json_metadata"
@@ -38,15 +38,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/kra_is_enabled.yaml
+++ b/actions/kra_is_enabled.yaml
@@ -12,7 +12,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "kra_is_enabled"
@@ -28,15 +28,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/krbtpolicy_mod.yaml
+++ b/actions/krbtpolicy_mod.yaml
@@ -58,7 +58,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "krbtpolicy_mod"
@@ -74,15 +74,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/krbtpolicy_reset.yaml
+++ b/actions/krbtpolicy_reset.yaml
@@ -22,7 +22,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "krbtpolicy_reset"
@@ -38,15 +38,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/krbtpolicy_show.yaml
+++ b/actions/krbtpolicy_show.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "krbtpolicy_show"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/location_add.yaml
+++ b/actions/location_add.yaml
@@ -32,7 +32,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "location_add"
@@ -48,15 +48,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/location_del.yaml
+++ b/actions/location_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "location_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/location_find.yaml
+++ b/actions/location_find.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "location_find"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/location_mod.yaml
+++ b/actions/location_mod.yaml
@@ -40,7 +40,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "location_mod"
@@ -56,15 +56,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/location_show.yaml
+++ b/actions/location_show.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "location_show"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/login.yaml
+++ b/actions/login.yaml
@@ -8,7 +8,7 @@ pack: freeipa
 parameters:
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "login"
@@ -24,15 +24,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/migrate_ds.yaml
+++ b/actions/migrate_ds.yaml
@@ -56,7 +56,7 @@ parameters:
   groupobjectclass:
     type: string
     required: true
-    default: [u'groupOfUniqueNames', u'groupOfNames']
+    default: ['groupOfUniqueNames', 'groupOfNames']
   groupoverwritegid:
     type: boolean
     required: true
@@ -99,12 +99,12 @@ parameters:
   userobjectclass:
     type: string
     required: true
-    default: [u'person']
+    default: ['person']
   version:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "migrate_ds"
@@ -120,15 +120,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/netgroup_add.yaml
+++ b/actions/netgroup_add.yaml
@@ -52,7 +52,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "netgroup_add"
@@ -68,15 +68,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/netgroup_add_member.yaml
+++ b/actions/netgroup_add_member.yaml
@@ -46,7 +46,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "netgroup_add_member"
@@ -62,15 +62,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/netgroup_del.yaml
+++ b/actions/netgroup_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "netgroup_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/netgroup_find.yaml
+++ b/actions/netgroup_find.yaml
@@ -112,7 +112,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "netgroup_find"
@@ -128,15 +128,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/netgroup_mod.yaml
+++ b/actions/netgroup_mod.yaml
@@ -60,7 +60,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "netgroup_mod"
@@ -76,15 +76,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/netgroup_remove_member.yaml
+++ b/actions/netgroup_remove_member.yaml
@@ -46,7 +46,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "netgroup_remove_member"
@@ -62,15 +62,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/netgroup_show.yaml
+++ b/actions/netgroup_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "netgroup_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/otpconfig_mod.yaml
+++ b/actions/otpconfig_mod.yaml
@@ -44,7 +44,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "otpconfig_mod"
@@ -60,15 +60,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/otpconfig_show.yaml
+++ b/actions/otpconfig_show.yaml
@@ -24,7 +24,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "otpconfig_show"
@@ -40,15 +40,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/otptoken_add.yaml
+++ b/actions/otptoken_add.yaml
@@ -97,7 +97,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "otptoken_add"
@@ -113,15 +113,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/otptoken_add_managedby.yaml
+++ b/actions/otptoken_add_managedby.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "otptoken_add_managedby"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/otptoken_del.yaml
+++ b/actions/otptoken_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "otptoken_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/otptoken_find.yaml
+++ b/actions/otptoken_find.yaml
@@ -82,7 +82,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "otptoken_find"
@@ -98,15 +98,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/otptoken_mod.yaml
+++ b/actions/otptoken_mod.yaml
@@ -60,7 +60,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "otptoken_mod"
@@ -76,15 +76,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/otptoken_remove_managedby.yaml
+++ b/actions/otptoken_remove_managedby.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "otptoken_remove_managedby"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/otptoken_show.yaml
+++ b/actions/otptoken_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "otptoken_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/output_find.yaml
+++ b/actions/output_find.yaml
@@ -28,7 +28,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "output_find"
@@ -44,15 +44,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/output_show.yaml
+++ b/actions/output_show.yaml
@@ -24,7 +24,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "output_show"
@@ -40,15 +40,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/param_find.yaml
+++ b/actions/param_find.yaml
@@ -28,7 +28,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "param_find"
@@ -44,15 +44,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/param_show.yaml
+++ b/actions/param_show.yaml
@@ -24,7 +24,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "param_show"
@@ -40,15 +40,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/passwd.yaml
+++ b/actions/passwd.yaml
@@ -25,7 +25,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "passwd"
@@ -41,15 +41,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/permission_add.yaml
+++ b/actions/permission_add.yaml
@@ -97,7 +97,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "permission_add"
@@ -113,15 +113,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/permission_add_member.yaml
+++ b/actions/permission_add_member.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "permission_add_member"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/permission_add_noaci.yaml
+++ b/actions/permission_add_noaci.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "permission_add_noaci"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/permission_del.yaml
+++ b/actions/permission_del.yaml
@@ -23,7 +23,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "permission_del"
@@ -39,15 +39,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/permission_find.yaml
+++ b/actions/permission_find.yaml
@@ -110,7 +110,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "permission_find"
@@ -126,15 +126,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/permission_mod.yaml
+++ b/actions/permission_mod.yaml
@@ -114,7 +114,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "permission_mod"
@@ -130,15 +130,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/permission_remove_member.yaml
+++ b/actions/permission_remove_member.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "permission_remove_member"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/permission_show.yaml
+++ b/actions/permission_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "permission_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/ping.yaml
+++ b/actions/ping.yaml
@@ -12,7 +12,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "ping"
@@ -28,15 +28,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/pkinit_status.yaml
+++ b/actions/pkinit_status.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "pkinit_status"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/plugins.yaml
+++ b/actions/plugins.yaml
@@ -20,7 +20,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "plugins"
@@ -36,15 +36,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/privilege_add.yaml
+++ b/actions/privilege_add.yaml
@@ -36,7 +36,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "privilege_add"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/privilege_add_member.yaml
+++ b/actions/privilege_add_member.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "privilege_add_member"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/privilege_add_permission.yaml
+++ b/actions/privilege_add_permission.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "privilege_add_permission"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/privilege_del.yaml
+++ b/actions/privilege_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "privilege_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/privilege_find.yaml
+++ b/actions/privilege_find.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "privilege_find"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/privilege_mod.yaml
+++ b/actions/privilege_mod.yaml
@@ -46,7 +46,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "privilege_mod"
@@ -62,15 +62,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/privilege_remove_member.yaml
+++ b/actions/privilege_remove_member.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "privilege_remove_member"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/privilege_remove_permission.yaml
+++ b/actions/privilege_remove_permission.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "privilege_remove_permission"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/privilege_show.yaml
+++ b/actions/privilege_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "privilege_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/pwpolicy_add.yaml
+++ b/actions/pwpolicy_add.yaml
@@ -48,7 +48,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "pwpolicy_add"
@@ -64,15 +64,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/pwpolicy_del.yaml
+++ b/actions/pwpolicy_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "pwpolicy_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/pwpolicy_find.yaml
+++ b/actions/pwpolicy_find.yaml
@@ -50,7 +50,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "pwpolicy_find"
@@ -66,15 +66,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/pwpolicy_mod.yaml
+++ b/actions/pwpolicy_mod.yaml
@@ -56,7 +56,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "pwpolicy_mod"
@@ -72,15 +72,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/pwpolicy_show.yaml
+++ b/actions/pwpolicy_show.yaml
@@ -28,7 +28,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "pwpolicy_show"
@@ -44,15 +44,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/radiusproxy_add.yaml
+++ b/actions/radiusproxy_add.yaml
@@ -43,7 +43,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "radiusproxy_add"
@@ -59,15 +59,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/radiusproxy_del.yaml
+++ b/actions/radiusproxy_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "radiusproxy_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/radiusproxy_find.yaml
+++ b/actions/radiusproxy_find.yaml
@@ -45,7 +45,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "radiusproxy_find"
@@ -61,15 +61,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/radiusproxy_mod.yaml
+++ b/actions/radiusproxy_mod.yaml
@@ -53,7 +53,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "radiusproxy_mod"
@@ -69,15 +69,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/radiusproxy_show.yaml
+++ b/actions/radiusproxy_show.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "radiusproxy_show"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/realmdomains_mod.yaml
+++ b/actions/realmdomains_mod.yaml
@@ -48,7 +48,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "realmdomains_mod"
@@ -64,15 +64,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/realmdomains_show.yaml
+++ b/actions/realmdomains_show.yaml
@@ -24,7 +24,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "realmdomains_show"
@@ -40,15 +40,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/role_add.yaml
+++ b/actions/role_add.yaml
@@ -36,7 +36,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "role_add"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/role_add_member.yaml
+++ b/actions/role_add_member.yaml
@@ -50,7 +50,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "role_add_member"
@@ -66,15 +66,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/role_add_privilege.yaml
+++ b/actions/role_add_privilege.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "role_add_privilege"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/role_del.yaml
+++ b/actions/role_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "role_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/role_find.yaml
+++ b/actions/role_find.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "role_find"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/role_mod.yaml
+++ b/actions/role_mod.yaml
@@ -46,7 +46,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "role_mod"
@@ -62,15 +62,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/role_remove_member.yaml
+++ b/actions/role_remove_member.yaml
@@ -50,7 +50,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "role_remove_member"
@@ -66,15 +66,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/role_remove_privilege.yaml
+++ b/actions/role_remove_privilege.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "role_remove_privilege"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/role_show.yaml
+++ b/actions/role_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "role_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/schema.yaml
+++ b/actions/schema.yaml
@@ -16,7 +16,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "schema"
@@ -32,15 +32,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/selfservice_add.yaml
+++ b/actions/selfservice_add.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "selfservice_add"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/selfservice_del.yaml
+++ b/actions/selfservice_del.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "selfservice_del"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/selfservice_find.yaml
+++ b/actions/selfservice_find.yaml
@@ -36,7 +36,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "selfservice_find"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/selfservice_mod.yaml
+++ b/actions/selfservice_mod.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "selfservice_mod"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/selfservice_show.yaml
+++ b/actions/selfservice_show.yaml
@@ -22,7 +22,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "selfservice_show"
@@ -38,15 +38,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/selinuxusermap_add.yaml
+++ b/actions/selinuxusermap_add.yaml
@@ -52,7 +52,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "selinuxusermap_add"
@@ -68,15 +68,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/selinuxusermap_add_host.yaml
+++ b/actions/selinuxusermap_add_host.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "selinuxusermap_add_host"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/selinuxusermap_add_user.yaml
+++ b/actions/selinuxusermap_add_user.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "selinuxusermap_add_user"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/selinuxusermap_del.yaml
+++ b/actions/selinuxusermap_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "selinuxusermap_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/selinuxusermap_disable.yaml
+++ b/actions/selinuxusermap_disable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "selinuxusermap_disable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/selinuxusermap_enable.yaml
+++ b/actions/selinuxusermap_enable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "selinuxusermap_enable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/selinuxusermap_find.yaml
+++ b/actions/selinuxusermap_find.yaml
@@ -54,7 +54,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "selinuxusermap_find"
@@ -70,15 +70,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/selinuxusermap_mod.yaml
+++ b/actions/selinuxusermap_mod.yaml
@@ -60,7 +60,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "selinuxusermap_mod"
@@ -76,15 +76,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/selinuxusermap_remove_host.yaml
+++ b/actions/selinuxusermap_remove_host.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "selinuxusermap_remove_host"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/selinuxusermap_remove_user.yaml
+++ b/actions/selinuxusermap_remove_user.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "selinuxusermap_remove_user"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/selinuxusermap_show.yaml
+++ b/actions/selinuxusermap_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "selinuxusermap_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/server_conncheck.yaml
+++ b/actions/server_conncheck.yaml
@@ -16,7 +16,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "server_conncheck"
@@ -32,15 +32,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/server_del.yaml
+++ b/actions/server_del.yaml
@@ -31,7 +31,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "server_del"
@@ -47,15 +47,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/server_find.yaml
+++ b/actions/server_find.yaml
@@ -60,7 +60,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "server_find"
@@ -76,15 +76,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/server_mod.yaml
+++ b/actions/server_mod.yaml
@@ -46,7 +46,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "server_mod"
@@ -62,15 +62,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/server_role_find.yaml
+++ b/actions/server_role_find.yaml
@@ -43,7 +43,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "server_role_find"
@@ -59,15 +59,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/server_role_show.yaml
+++ b/actions/server_role_show.yaml
@@ -24,7 +24,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "server_role_show"
@@ -40,15 +40,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/server_show.yaml
+++ b/actions/server_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "server_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/server_state.yaml
+++ b/actions/server_state.yaml
@@ -20,7 +20,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "server_state"
@@ -36,15 +36,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_add.yaml
+++ b/actions/service_add.yaml
@@ -71,7 +71,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_add"
@@ -87,15 +87,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_add_cert.yaml
+++ b/actions/service_add_cert.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_add_cert"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_add_host.yaml
+++ b/actions/service_add_host.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_add_host"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_add_principal.yaml
+++ b/actions/service_add_principal.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_add_principal"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_add_smb.yaml
+++ b/actions/service_add_smb.yaml
@@ -44,7 +44,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_add_smb"
@@ -60,15 +60,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_allow_create_keytab.yaml
+++ b/actions/service_allow_create_keytab.yaml
@@ -42,7 +42,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_allow_create_keytab"
@@ -58,15 +58,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_allow_retrieve_keytab.yaml
+++ b/actions/service_allow_retrieve_keytab.yaml
@@ -42,7 +42,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_allow_retrieve_keytab"
@@ -58,15 +58,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_del.yaml
+++ b/actions/service_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_disable.yaml
+++ b/actions/service_disable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_disable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_disallow_create_keytab.yaml
+++ b/actions/service_disallow_create_keytab.yaml
@@ -42,7 +42,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_disallow_create_keytab"
@@ -58,15 +58,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_disallow_retrieve_keytab.yaml
+++ b/actions/service_disallow_retrieve_keytab.yaml
@@ -42,7 +42,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_disallow_retrieve_keytab"
@@ -58,15 +58,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_find.yaml
+++ b/actions/service_find.yaml
@@ -67,7 +67,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_find"
@@ -83,15 +83,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_mod.yaml
+++ b/actions/service_mod.yaml
@@ -75,7 +75,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_mod"
@@ -91,15 +91,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_remove_cert.yaml
+++ b/actions/service_remove_cert.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_remove_cert"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_remove_host.yaml
+++ b/actions/service_remove_host.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_remove_host"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_remove_principal.yaml
+++ b/actions/service_remove_principal.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_remove_principal"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/service_show.yaml
+++ b/actions/service_show.yaml
@@ -32,7 +32,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "service_show"
@@ -48,15 +48,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/servicedelegationrule_add.yaml
+++ b/actions/servicedelegationrule_add.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "servicedelegationrule_add"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/servicedelegationrule_add_member.yaml
+++ b/actions/servicedelegationrule_add_member.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "servicedelegationrule_add_member"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/servicedelegationrule_add_target.yaml
+++ b/actions/servicedelegationrule_add_target.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "servicedelegationrule_add_target"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/servicedelegationrule_del.yaml
+++ b/actions/servicedelegationrule_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "servicedelegationrule_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/servicedelegationrule_find.yaml
+++ b/actions/servicedelegationrule_find.yaml
@@ -36,7 +36,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "servicedelegationrule_find"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/servicedelegationrule_remove_member.yaml
+++ b/actions/servicedelegationrule_remove_member.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "servicedelegationrule_remove_member"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/servicedelegationrule_remove_target.yaml
+++ b/actions/servicedelegationrule_remove_target.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "servicedelegationrule_remove_target"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/servicedelegationrule_show.yaml
+++ b/actions/servicedelegationrule_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "servicedelegationrule_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/servicedelegationtarget_add.yaml
+++ b/actions/servicedelegationtarget_add.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "servicedelegationtarget_add"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/servicedelegationtarget_add_member.yaml
+++ b/actions/servicedelegationtarget_add_member.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "servicedelegationtarget_add_member"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/servicedelegationtarget_del.yaml
+++ b/actions/servicedelegationtarget_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "servicedelegationtarget_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/servicedelegationtarget_find.yaml
+++ b/actions/servicedelegationtarget_find.yaml
@@ -32,7 +32,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "servicedelegationtarget_find"
@@ -48,15 +48,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/servicedelegationtarget_remove_member.yaml
+++ b/actions/servicedelegationtarget_remove_member.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "servicedelegationtarget_remove_member"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/servicedelegationtarget_show.yaml
+++ b/actions/servicedelegationtarget_show.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "servicedelegationtarget_show"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/session_logout.yaml
+++ b/actions/session_logout.yaml
@@ -12,7 +12,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "session_logout"
@@ -28,15 +28,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sidgen_was_run.yaml
+++ b/actions/sidgen_was_run.yaml
@@ -12,7 +12,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sidgen_was_run"
@@ -28,15 +28,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/stageuser_activate.yaml
+++ b/actions/stageuser_activate.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "stageuser_activate"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/stageuser_add.yaml
+++ b/actions/stageuser_add.yaml
@@ -151,7 +151,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "stageuser_add"
@@ -167,15 +167,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/stageuser_add_cert.yaml
+++ b/actions/stageuser_add_cert.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "stageuser_add_cert"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/stageuser_add_certmapdata.yaml
+++ b/actions/stageuser_add_certmapdata.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "stageuser_add_certmapdata"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/stageuser_add_manager.yaml
+++ b/actions/stageuser_add_manager.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "stageuser_add_manager"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/stageuser_add_principal.yaml
+++ b/actions/stageuser_add_principal.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "stageuser_add_principal"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/stageuser_del.yaml
+++ b/actions/stageuser_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "stageuser_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/stageuser_find.yaml
+++ b/actions/stageuser_find.yaml
@@ -214,7 +214,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "stageuser_find"
@@ -230,15 +230,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/stageuser_mod.yaml
+++ b/actions/stageuser_mod.yaml
@@ -190,7 +190,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "stageuser_mod"
@@ -206,15 +206,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/stageuser_remove_cert.yaml
+++ b/actions/stageuser_remove_cert.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "stageuser_remove_cert"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/stageuser_remove_certmapdata.yaml
+++ b/actions/stageuser_remove_certmapdata.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "stageuser_remove_certmapdata"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/stageuser_remove_manager.yaml
+++ b/actions/stageuser_remove_manager.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "stageuser_remove_manager"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/stageuser_remove_principal.yaml
+++ b/actions/stageuser_remove_principal.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "stageuser_remove_principal"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/stageuser_show.yaml
+++ b/actions/stageuser_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "stageuser_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudocmd_add.yaml
+++ b/actions/sudocmd_add.yaml
@@ -36,7 +36,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudocmd_add"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudocmd_del.yaml
+++ b/actions/sudocmd_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudocmd_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudocmd_find.yaml
+++ b/actions/sudocmd_find.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudocmd_find"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudocmd_mod.yaml
+++ b/actions/sudocmd_mod.yaml
@@ -44,7 +44,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudocmd_mod"
@@ -60,15 +60,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudocmd_show.yaml
+++ b/actions/sudocmd_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudocmd_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudocmdgroup_add.yaml
+++ b/actions/sudocmdgroup_add.yaml
@@ -36,7 +36,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudocmdgroup_add"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudocmdgroup_add_member.yaml
+++ b/actions/sudocmdgroup_add_member.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudocmdgroup_add_member"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudocmdgroup_del.yaml
+++ b/actions/sudocmdgroup_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudocmdgroup_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudocmdgroup_find.yaml
+++ b/actions/sudocmdgroup_find.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudocmdgroup_find"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudocmdgroup_mod.yaml
+++ b/actions/sudocmdgroup_mod.yaml
@@ -44,7 +44,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudocmdgroup_mod"
@@ -60,15 +60,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudocmdgroup_remove_member.yaml
+++ b/actions/sudocmdgroup_remove_member.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudocmdgroup_remove_member"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudocmdgroup_show.yaml
+++ b/actions/sudocmdgroup_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudocmdgroup_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_add.yaml
+++ b/actions/sudorule_add.yaml
@@ -76,7 +76,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_add"
@@ -92,15 +92,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_add_allow_command.yaml
+++ b/actions/sudorule_add_allow_command.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_add_allow_command"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_add_deny_command.yaml
+++ b/actions/sudorule_add_deny_command.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_add_deny_command"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_add_host.yaml
+++ b/actions/sudorule_add_host.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_add_host"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_add_option.yaml
+++ b/actions/sudorule_add_option.yaml
@@ -28,7 +28,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_add_option"
@@ -44,15 +44,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_add_runasgroup.yaml
+++ b/actions/sudorule_add_runasgroup.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_add_runasgroup"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_add_runasuser.yaml
+++ b/actions/sudorule_add_runasuser.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_add_runasuser"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_add_user.yaml
+++ b/actions/sudorule_add_user.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_add_user"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_del.yaml
+++ b/actions/sudorule_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_disable.yaml
+++ b/actions/sudorule_disable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_disable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_enable.yaml
+++ b/actions/sudorule_enable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_enable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_find.yaml
+++ b/actions/sudorule_find.yaml
@@ -78,7 +78,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_find"
@@ -94,15 +94,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_mod.yaml
+++ b/actions/sudorule_mod.yaml
@@ -86,7 +86,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_mod"
@@ -102,15 +102,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_remove_allow_command.yaml
+++ b/actions/sudorule_remove_allow_command.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_remove_allow_command"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_remove_deny_command.yaml
+++ b/actions/sudorule_remove_deny_command.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_remove_deny_command"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_remove_host.yaml
+++ b/actions/sudorule_remove_host.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_remove_host"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_remove_option.yaml
+++ b/actions/sudorule_remove_option.yaml
@@ -28,7 +28,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_remove_option"
@@ -44,15 +44,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_remove_runasgroup.yaml
+++ b/actions/sudorule_remove_runasgroup.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_remove_runasgroup"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_remove_runasuser.yaml
+++ b/actions/sudorule_remove_runasuser.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_remove_runasuser"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_remove_user.yaml
+++ b/actions/sudorule_remove_user.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_remove_user"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/sudorule_show.yaml
+++ b/actions/sudorule_show.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "sudorule_show"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/topic_find.yaml
+++ b/actions/topic_find.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "topic_find"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/topic_show.yaml
+++ b/actions/topic_show.yaml
@@ -22,7 +22,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "topic_show"
@@ -38,15 +38,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/topologysegment_add.yaml
+++ b/actions/topologysegment_add.yaml
@@ -59,7 +59,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "topologysegment_add"
@@ -75,15 +75,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/topologysegment_del.yaml
+++ b/actions/topologysegment_del.yaml
@@ -21,7 +21,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "topologysegment_del"
@@ -37,15 +37,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/topologysegment_find.yaml
+++ b/actions/topologysegment_find.yaml
@@ -60,7 +60,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "topologysegment_find"
@@ -76,15 +76,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/topologysegment_mod.yaml
+++ b/actions/topologysegment_mod.yaml
@@ -54,7 +54,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "topologysegment_mod"
@@ -70,15 +70,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/topologysegment_reinitialize.yaml
+++ b/actions/topologysegment_reinitialize.yaml
@@ -28,7 +28,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "topologysegment_reinitialize"
@@ -44,15 +44,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/topologysegment_show.yaml
+++ b/actions/topologysegment_show.yaml
@@ -28,7 +28,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "topologysegment_show"
@@ -44,15 +44,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/topologysuffix_add.yaml
+++ b/actions/topologysuffix_add.yaml
@@ -32,7 +32,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "topologysuffix_add"
@@ -48,15 +48,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/topologysuffix_del.yaml
+++ b/actions/topologysuffix_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "topologysuffix_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/topologysuffix_find.yaml
+++ b/actions/topologysuffix_find.yaml
@@ -34,7 +34,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "topologysuffix_find"
@@ -50,15 +50,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/topologysuffix_mod.yaml
+++ b/actions/topologysuffix_mod.yaml
@@ -40,7 +40,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "topologysuffix_mod"
@@ -56,15 +56,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/topologysuffix_show.yaml
+++ b/actions/topologysuffix_show.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "topologysuffix_show"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/topologysuffix_verify.yaml
+++ b/actions/topologysuffix_verify.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "topologysuffix_verify"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/trust_add.yaml
+++ b/actions/trust_add.yaml
@@ -63,7 +63,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "trust_add"
@@ -79,15 +79,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/trust_del.yaml
+++ b/actions/trust_del.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "trust_del"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/trust_enable_agent.yaml
+++ b/actions/trust_enable_agent.yaml
@@ -18,7 +18,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "trust_enable_agent"
@@ -34,15 +34,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/trust_fetch_domains.yaml
+++ b/actions/trust_fetch_domains.yaml
@@ -33,7 +33,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "trust_fetch_domains"
@@ -49,15 +49,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/trust_find.yaml
+++ b/actions/trust_find.yaml
@@ -44,7 +44,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "trust_find"
@@ -60,15 +60,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/trust_mod.yaml
+++ b/actions/trust_mod.yaml
@@ -50,7 +50,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "trust_mod"
@@ -66,15 +66,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/trust_resolve.yaml
+++ b/actions/trust_resolve.yaml
@@ -23,7 +23,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "trust_resolve"
@@ -39,15 +39,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/trust_show.yaml
+++ b/actions/trust_show.yaml
@@ -26,7 +26,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "trust_show"
@@ -42,15 +42,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/trustconfig_mod.yaml
+++ b/actions/trustconfig_mod.yaml
@@ -45,7 +45,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "trustconfig_mod"
@@ -61,15 +61,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/trustconfig_show.yaml
+++ b/actions/trustconfig_show.yaml
@@ -31,7 +31,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "trustconfig_show"
@@ -47,15 +47,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/trustdomain_add.yaml
+++ b/actions/trustdomain_add.yaml
@@ -43,7 +43,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "trustdomain_add"
@@ -59,15 +59,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/trustdomain_del.yaml
+++ b/actions/trustdomain_del.yaml
@@ -21,7 +21,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "trustdomain_del"
@@ -37,15 +37,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/trustdomain_disable.yaml
+++ b/actions/trustdomain_disable.yaml
@@ -16,7 +16,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "trustdomain_disable"
@@ -32,15 +32,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/trustdomain_enable.yaml
+++ b/actions/trustdomain_enable.yaml
@@ -16,7 +16,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "trustdomain_enable"
@@ -32,15 +32,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/trustdomain_find.yaml
+++ b/actions/trustdomain_find.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "trustdomain_find"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/trustdomain_mod.yaml
+++ b/actions/trustdomain_mod.yaml
@@ -51,7 +51,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "trustdomain_mod"
@@ -67,15 +67,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_add.yaml
+++ b/actions/user_add.yaml
@@ -156,7 +156,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_add"
@@ -172,15 +172,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_add_cert.yaml
+++ b/actions/user_add_cert.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_add_cert"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_add_certmapdata.yaml
+++ b/actions/user_add_certmapdata.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_add_certmapdata"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_add_manager.yaml
+++ b/actions/user_add_manager.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_add_manager"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_add_principal.yaml
+++ b/actions/user_add_principal.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_add_principal"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_del.yaml
+++ b/actions/user_del.yaml
@@ -21,7 +21,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_del"
@@ -37,15 +37,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_disable.yaml
+++ b/actions/user_disable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_disable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_enable.yaml
+++ b/actions/user_enable.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_enable"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_find.yaml
+++ b/actions/user_find.yaml
@@ -224,7 +224,7 @@ parameters:
     default: False
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_find"
@@ -240,15 +240,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_mod.yaml
+++ b/actions/user_mod.yaml
@@ -193,7 +193,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_mod"
@@ -209,15 +209,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_remove_cert.yaml
+++ b/actions/user_remove_cert.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_remove_cert"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_remove_certmapdata.yaml
+++ b/actions/user_remove_certmapdata.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_remove_certmapdata"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_remove_manager.yaml
+++ b/actions/user_remove_manager.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_remove_manager"
@@ -46,15 +46,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_remove_principal.yaml
+++ b/actions/user_remove_principal.yaml
@@ -29,7 +29,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_remove_principal"
@@ -45,15 +45,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_show.yaml
+++ b/actions/user_show.yaml
@@ -32,7 +32,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_show"
@@ -48,15 +48,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_stage.yaml
+++ b/actions/user_stage.yaml
@@ -19,7 +19,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_stage"
@@ -35,15 +35,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_status.yaml
+++ b/actions/user_status.yaml
@@ -22,7 +22,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_status"
@@ -38,15 +38,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_undel.yaml
+++ b/actions/user_undel.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_undel"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/user_unlock.yaml
+++ b/actions/user_unlock.yaml
@@ -14,7 +14,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "user_unlock"
@@ -30,15 +30,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/vault_add_internal.yaml
+++ b/actions/vault_add_internal.yaml
@@ -57,7 +57,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "vault_add_internal"
@@ -73,15 +73,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/vault_add_member.yaml
+++ b/actions/vault_add_member.yaml
@@ -46,7 +46,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "vault_add_member"
@@ -62,15 +62,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/vault_add_owner.yaml
+++ b/actions/vault_add_owner.yaml
@@ -46,7 +46,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "vault_add_owner"
@@ -62,15 +62,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/vault_archive_internal.yaml
+++ b/actions/vault_archive_internal.yaml
@@ -36,7 +36,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "vault_archive_internal"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/vault_del.yaml
+++ b/actions/vault_del.yaml
@@ -27,7 +27,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "vault_del"
@@ -43,15 +43,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/vault_find.yaml
+++ b/actions/vault_find.yaml
@@ -62,7 +62,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "vault_find"
@@ -78,15 +78,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/vault_mod_internal.yaml
+++ b/actions/vault_mod_internal.yaml
@@ -64,7 +64,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "vault_mod_internal"
@@ -80,15 +80,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/vault_remove_member.yaml
+++ b/actions/vault_remove_member.yaml
@@ -46,7 +46,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "vault_remove_member"
@@ -62,15 +62,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/vault_remove_owner.yaml
+++ b/actions/vault_remove_owner.yaml
@@ -46,7 +46,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "vault_remove_owner"
@@ -62,15 +62,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/vault_retrieve_internal.yaml
+++ b/actions/vault_retrieve_internal.yaml
@@ -32,7 +32,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "vault_retrieve_internal"
@@ -48,15 +48,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/vault_show.yaml
+++ b/actions/vault_show.yaml
@@ -38,7 +38,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "vault_show"
@@ -54,15 +54,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/vaultconfig_show.yaml
+++ b/actions/vaultconfig_show.yaml
@@ -22,7 +22,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "vaultconfig_show"
@@ -38,15 +38,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/vaultcontainer_add_owner.yaml
+++ b/actions/vaultcontainer_add_owner.yaml
@@ -44,7 +44,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "vaultcontainer_add_owner"
@@ -60,15 +60,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/vaultcontainer_del.yaml
+++ b/actions/vaultcontainer_del.yaml
@@ -24,7 +24,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "vaultcontainer_del"
@@ -40,15 +40,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/vaultcontainer_remove_owner.yaml
+++ b/actions/vaultcontainer_remove_owner.yaml
@@ -44,7 +44,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "vaultcontainer_remove_owner"
@@ -60,15 +60,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/actions/vaultcontainer_show.yaml
+++ b/actions/vaultcontainer_show.yaml
@@ -36,7 +36,7 @@ parameters:
     type: string
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "vaultcontainer_show"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -10,15 +10,15 @@ connections:
 connection:
   type: "object"
   properties:
-    server:
+    ipa_server:
       type: string
       description: "IP/Hostname of the FreeIPA server"
       required: true
-    username:
+    ipa_username:
       type: string
       description: "Username to login to the FreeIPA server"
       required: true
-    password:
+    ipa_password:
       type: string
       description: "Password to login to the FreeIPA server"
       required: true

--- a/etc/templates/action.yaml.j2
+++ b/etc/templates/action.yaml.j2
@@ -36,7 +36,7 @@ parameters:
 {%- endif %}
 ############################################################################
 # begin static invocation params
-  method:
+  ipa_method:
     type: string
     description: "Name of IPA command to be executed."
     default: "{{ name }}"
@@ -52,15 +52,15 @@ parameters:
     type: string
     description: "Name of <connection> from this pack's configuration that specifies how to connect to a IPA server."
     required: false
-  server:
+  ipa_server:
     type: string
     description: "Optional override of the IPA server in <connection> (required if <connection> is not specified)."
     required: false
-  username:
+  ipa_username:
     type: string
     description: "Optional override of the IPA username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
     required: false
-  password:
+  ipa_password:
     type: string
     description: "Optional override of the IPA password in <connection>. (required if <connection> is not specified)"
     required: false

--- a/freeipa.yaml.example
+++ b/freeipa.yaml.example
@@ -3,14 +3,14 @@ verify_ssl: false
 
 connections:
   default:
-    server: "ipa1.dev.domain.tld"
-    username: "devusername"
-    password: "devpassword"
+    ipa_server: "ipa1.dev.domain.tld"
+    ipa_username: "devusername"
+    ipa_password: "devpassword"
   qa:
-    server: "ipa1.qa.domain.tld"
-    username: "qausername"
-    password: "qapassword"
+    ipa_server: "ipa1.qa.domain.tld"
+    ipa_username: "qausername"
+    ipa_password: "qapassword"
   prod:
-    server: "ipa1.prod.domain.tld"
-    username: "produsername"
-    password: "prodpassword"
+    ipa_server: "ipa1.prod.domain.tld"
+    ipa_username: "produsername"
+    ipa_password: "prodpassword"

--- a/pack.yaml
+++ b/pack.yaml
@@ -10,7 +10,7 @@ keywords:
   - red
   - hat
   - authentication
-version: 1.0.0
+version: 1.1.0
 author: Encore Technologies
 email: code@encore.tech
 python_versions:

--- a/tests/fixtures/config_good.yaml
+++ b/tests/fixtures/config_good.yaml
@@ -1,15 +1,15 @@
 ---
 connections:
   default:
-    server: abc123
-    username: xxx
-    password: yyy
+    ipa_server: abc123
+    ipa_username: xxx
+    ipa_password: yyy
   base:
-    server: abc
-    username: Administrator
-    password: PassworD!
+    ipa_server: abc
+    ipa_username: Administrator
+    ipa_password: PassworD!
   full:
-    server: server1
-    username: user1
-    password: pwd1
+    ipa_server: server1
+    ipa_username: user1
+    ipa_password: pwd1
     verify_ssl: false

--- a/tests/fixtures/config_partial.yaml
+++ b/tests/fixtures/config_partial.yaml
@@ -1,15 +1,15 @@
 ---
 connections:
   missing-server:
-    username: user1
-    password: pwd1
+    ipa_username: user1
+    ipa_password: pwd1
   missing-username:
-    server: server1
-    password: pwd1
+    ipa_server: server1
+    ipa_password: pwd1
   missing-password:
-    server: server1
-    username: user1
+    ipa_server: server1
+    ipa_username: user1
   missing-verify-ssl:
-    server: server1
-    username: user1
-    password: xyz123
+    ipa_server: server1
+    ipa_username: user1
+    ipa_password: xyz123

--- a/tests/test_actions_ipa_action.py
+++ b/tests/test_actions_ipa_action.py
@@ -43,9 +43,9 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
     def test__resolve_connection_from_kwargs(self):
         action = self.get_action_instance(self.config_blank)
         kwargs = {'connection': None,
-                  'server': 'kwargs_server',
-                  'username': 'kwargs_user',
-                  'password': 'kwargs_password'}
+                  'ipa_server': 'kwargs_server',
+                  'ipa_username': 'kwargs_user',
+                  'ipa_password': 'kwargs_password'}
         connection_expected = copy.deepcopy(kwargs)
         connection_result = action._resolve_connection(**kwargs)
         self.assertEqual(connection_result, connection_expected)
@@ -53,9 +53,9 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
     def test__resolve_connection_from_kwargs_defaults(self):
         action = self.get_action_instance(self.config_blank)
         kwargs = {'connection': None,
-                  'server': 'kwargs_server',
-                  'username': 'kwargs_user',
-                  'password': 'kwargs_password'}
+                  'ipa_server': 'kwargs_server',
+                  'ipa_username': 'kwargs_user',
+                  'ipa_password': 'kwargs_password'}
         connection_expected = copy.deepcopy(kwargs)
         connection_result = action._resolve_connection(**kwargs)
         self.assertEqual(connection_result, connection_expected)
@@ -77,10 +77,10 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
         connection_name = 'full'
         connection_config = self.config_good['connections'][connection_name]
         kwargs = {'connection': connection_name,
-                  'server': 'kwargs_server',
-                  'username': 'kwargs_user'}
+                  'ipa_server': 'kwargs_server',
+                  'ipa_username': 'kwargs_user'}
         connection_expected = copy.deepcopy(kwargs)
-        connection_expected['password'] = connection_config['password']
+        connection_expected['ipa_password'] = connection_config['ipa_password']
         connection_expected['verify_ssl'] = connection_config['verify_ssl']
         connection_result = action._resolve_connection(**kwargs)
         self.assertEqual(connection_result, connection_expected)
@@ -133,13 +133,13 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
         mock_session.post.return_value = mock_response
         action.session = mock_session
 
-        url = 'https://{0}/ipa/session/login_password'.format(connection['server'])
-        headers = {"referer": 'https://{0}/ipa'.format(connection['server']),
+        url = 'https://{0}/ipa/session/login_password'.format(connection['ipa_server'])
+        headers = {"referer": 'https://{0}/ipa'.format(connection['ipa_server']),
                    "Content-Type": "application/x-www-form-urlencoded",
                    "Accept": "text/plain"}
         data = {
-            'user': connection['username'],
-            'password': connection['password']
+            'user': connection['ipa_username'],
+            'password': connection['ipa_password']
         }
 
         # execute
@@ -163,13 +163,13 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
         mock_session.post.return_value = mock_response
         action.session = mock_session
 
-        url = 'https://{0}/ipa/session/login_password'.format(connection['server'])
-        headers = {"referer": 'https://{0}/ipa'.format(connection['server']),
+        url = 'https://{0}/ipa/session/login_password'.format(connection['ipa_server'])
+        headers = {"referer": 'https://{0}/ipa'.format(connection['ipa_server']),
                    "Content-Type": "application/x-www-form-urlencoded",
                    "Accept": "text/plain"}
         data = {
-            'user': connection['username'],
-            'password': connection['password']
+            'user': connection['ipa_username'],
+            'password': connection['ipa_password']
         }
 
         # execute
@@ -193,13 +193,13 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
         mock_session.post.return_value = mock_response
         action.session = mock_session
 
-        url = 'https://{0}/ipa/session/login_password'.format(connection['server'])
-        headers = {"referer": 'https://{0}/ipa'.format(connection['server']),
+        url = 'https://{0}/ipa/session/login_password'.format(connection['ipa_server'])
+        headers = {"referer": 'https://{0}/ipa'.format(connection['ipa_server']),
                    "Content-Type": "application/x-www-form-urlencoded",
                    "Accept": "text/plain"}
         data = {
-            'user': connection['username'],
-            'password': connection['password']
+            'user': connection['ipa_username'],
+            'password': connection['ipa_password']
         }
 
         # execute
@@ -275,7 +275,7 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
         action = self.get_action_instance(self.config_good)
         connection = self.config_good['connections']['base']
 
-        server = connection['server']
+        server = connection['ipa_server']
         session = "session123"
         method = 'hostgroup_show'
         args = IPA_COMMAND_ARGS_OPTIONS[method]['args']
@@ -326,7 +326,7 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
         action = self.get_action_instance(self.config_good)
         connection = self.config_good['connections']['base']
 
-        server = connection['server']
+        server = connection['ipa_server']
         session = "session123"
         method = 'hostgroup_show'
         args = IPA_COMMAND_ARGS_OPTIONS[method]['args']
@@ -378,7 +378,7 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
         action = self.get_action_instance(self.config_good)
         connection = self.config_good['connections']['base']
 
-        server = connection['server']
+        server = connection['ipa_server']
         session = "session123"
         method = 'hostgroup_show'
         args = IPA_COMMAND_ARGS_OPTIONS[method]['args']
@@ -497,11 +497,11 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
     def test_run_login_existing_session(self):
         # setup
         action = self.get_action_instance(self.config_blank)
-        kwargs_dict = {'method': 'login',
+        kwargs_dict = {'ipa_method': 'login',
                        'session': 'session123',
-                       'server': 'server.domain.tld',
-                       'username': 'test',
-                       'password': 'abc123',
+                       'ipa_server': 'server.domain.tld',
+                       'ipa_username': 'test',
+                       'ipa_password': 'abc123',
                        'verify_ssl': False}
 
         # execute
@@ -515,11 +515,11 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
     def test_run_login_missing_session(self, mock__login):
         # setup
         action = self.get_action_instance(self.config_blank)
-        kwargs_dict = {'method': 'login',
-                       'server': 'server.domain.tld',
+        kwargs_dict = {'ipa_method': 'login',
+                       'ipa_server': 'server.domain.tld',
                        'session': None,
-                       'username': 'username123',
-                       'password': 'password123',
+                       'ipa_username': 'username123',
+                       'ipa_password': 'password123',
                        'verify_ssl': True}
         mock__login.return_value = 'session123'
 
@@ -535,11 +535,11 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
     def test_run_execute(self, mock__execute, mock__get_api_version):
         # setup
         action = self.get_action_instance(self.config_blank)
-        kwargs = {'method': 'host_add',
+        kwargs = {'ipa_method': 'host_add',
                   'session': 'session123',
-                  'server': 'server.domain.tld',
-                  'username': 'username123',
-                  'password': 'password123',
+                  'ipa_server': 'server.domain.tld',
+                  'ipa_username': 'username123',
+                  'ipa_password': 'password123',
                   'verify_ssl': True}
         mock__get_api_version.return_value = '1.234'
         mock__execute.return_value = (True, {'data': 'value'})
@@ -555,5 +555,5 @@ class TestActionsIpaAction(FreeIPABaseActionTestCase):
                                          'server.domain.tld',
                                          method='host_add',
                                          api_version='1.234',
-                                         username='username123',
-                                         password='password123')
+                                         ipa_username='username123',
+                                         ipa_password='password123')


### PR DESCRIPTION
This is a fix for Issue #6. Stackstorm 3.5 started verifying that parameter names in action files are unique and there were several actions in here that were created automatically with duplicate method, server, username, and password parameters.

Updated config and generate_actions template to rename connection variables. We can't simply remove one of the duplicates because some of the automatically generated params are expected to be different than what we get from the config (such as the server param in env.yaml).

NOTE: This is a breaking change for anyone that passes the server and credentials into actions instead of using a config connection or session